### PR TITLE
feat: FilterMatePublicAPI for inter-plugin communication

### DIFF
--- a/adapters/public_api/__init__.py
+++ b/adapters/public_api/__init__.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+"""
+FilterMate Public API Adapter.
+
+Provides the concrete implementation of the public API port
+for inter-plugin communication.
+
+Version: 4.7.0 (Sprint 1 - Narractive Integration)
+"""
+from .filter_mate_public_api import FilterMatePublicAPI  # noqa: F401
+
+__all__ = [
+    'FilterMatePublicAPI',
+]

--- a/adapters/public_api/filter_mate_public_api.py
+++ b/adapters/public_api/filter_mate_public_api.py
@@ -1,0 +1,312 @@
+# -*- coding: utf-8 -*-
+"""
+FilterMate Public API Adapter.
+
+Concrete implementation of IFilterMatePublicAPI for inter-plugin communication.
+Delegates to QGIS layer API and the existing FilterMate infrastructure.
+
+This adapter uses PyQt signals for event notification and delegates
+filter operations to QGIS's native setSubsetString mechanism.
+
+Version: 4.7.0 (Sprint 1 - Narractive Integration)
+"""
+import os
+from typing import Dict
+
+from qgis.PyQt.QtCore import QObject, pyqtSignal
+from qgis.core import QgsProject, QgsVectorLayer
+
+from ...core.ports.public_api_port import IFilterMatePublicAPI
+from ...infrastructure.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+class FilterMatePublicAPI(QObject, IFilterMatePublicAPI):
+    """
+    Public API for inter-plugin communication with FilterMate.
+
+    Emits PyQt signals so external plugins can react to filter changes.
+
+    Signals:
+        filter_applied(str, str, str): layer_name, expression, source_plugin
+        filter_cleared(str, str): layer_name, source_plugin
+        error_occurred(str, str): operation, error_message
+        about_to_unload(): Emitted when FilterMate is about to unload.
+
+    Example:
+        api = fm.get_public_api()
+        api.filter_applied.connect(my_handler)
+        api.apply_filter('communes', 'population > 10000', 'narractive')
+    """
+
+    # Signals for external consumers
+    filter_applied = pyqtSignal(str, str, str)   # layer_name, expression, source_plugin
+    filter_cleared = pyqtSignal(str, str)         # layer_name, source_plugin
+    error_occurred = pyqtSignal(str, str)          # operation, error_message
+    about_to_unload = pyqtSignal()
+
+    def __init__(self, plugin_instance):
+        """
+        Initialize the public API adapter.
+
+        Args:
+            plugin_instance: The main FilterMate plugin instance.
+        """
+        super().__init__()
+        self._plugin = plugin_instance
+        self._version = None
+        logger.info("FilterMatePublicAPI initialized")
+
+    def apply_filter(self, layer_name: str, filter_expr: str,
+                     source_plugin: str = "external") -> bool:
+        """
+        Apply a filter expression to a named layer.
+
+        Uses QGIS native setSubsetString for reliable filter application.
+        Falls back to safe_set_subset_string when available for enhanced
+        error handling on PostgreSQL layers.
+
+        Args:
+            layer_name: Name of the QGIS layer to filter.
+            filter_expr: SQL WHERE clause (without WHERE keyword).
+            source_plugin: Name of the calling plugin (for logging/audit).
+
+        Returns:
+            True if filter was applied successfully, False otherwise.
+        """
+        operation = f"apply_filter({layer_name!r})"
+        logger.info(
+            f"PublicAPI: {operation} from {source_plugin!r}, "
+            f"expr={filter_expr!r}"
+        )
+
+        try:
+            layer = self._find_vector_layer(layer_name)
+            if layer is None:
+                msg = f"Layer not found: {layer_name!r}"
+                logger.warning(f"PublicAPI: {msg}")
+                self.error_occurred.emit(operation, msg)
+                return False
+
+            if not layer.isValid():
+                msg = f"Layer is not valid: {layer_name!r}"
+                logger.warning(f"PublicAPI: {msg}")
+                self.error_occurred.emit(operation, msg)
+                return False
+
+            # Use safe_set_subset_string if available (handles PostgreSQL type casting)
+            success = self._safe_set_subset(layer, filter_expr)
+
+            if success:
+                logger.info(
+                    f"PublicAPI: Filter applied on {layer_name!r} "
+                    f"by {source_plugin!r}"
+                )
+                self.filter_applied.emit(layer_name, filter_expr, source_plugin)
+            else:
+                msg = (
+                    f"setSubsetString failed for layer {layer_name!r}. "
+                    f"Check expression syntax."
+                )
+                logger.warning(f"PublicAPI: {msg}")
+                self.error_occurred.emit(operation, msg)
+
+            return success
+
+        except Exception as e:
+            msg = f"Unexpected error: {e}"
+            logger.error(f"PublicAPI: {operation} - {msg}", exc_info=True)
+            self.error_occurred.emit(operation, msg)
+            return False
+
+    def get_active_filters(self) -> Dict[str, str]:
+        """
+        Return active filters for all vector layers in the project.
+
+        Returns:
+            Dict mapping layer_name to filter_expression for all layers
+            that currently have an active subset string filter.
+        """
+        active_filters = {}
+        try:
+            project = QgsProject.instance()
+            for layer in project.mapLayers().values():
+                if not isinstance(layer, QgsVectorLayer):
+                    continue
+                if not layer.isValid():
+                    continue
+                subset = layer.subsetString()
+                if subset and subset.strip():
+                    active_filters[layer.name()] = subset
+        except Exception as e:
+            logger.error(
+                f"PublicAPI: get_active_filters error: {e}", exc_info=True
+            )
+            self.error_occurred.emit("get_active_filters", str(e))
+
+        return active_filters
+
+    def clear_filter(self, layer_name: str) -> bool:
+        """
+        Clear the filter on a specific layer.
+
+        Args:
+            layer_name: Name of the QGIS layer to clear.
+
+        Returns:
+            True if filter was cleared successfully, False otherwise.
+        """
+        operation = f"clear_filter({layer_name!r})"
+        logger.info(f"PublicAPI: {operation}")
+
+        try:
+            layer = self._find_vector_layer(layer_name)
+            if layer is None:
+                msg = f"Layer not found: {layer_name!r}"
+                logger.warning(f"PublicAPI: {msg}")
+                self.error_occurred.emit(operation, msg)
+                return False
+
+            if not layer.isValid():
+                msg = f"Layer is not valid: {layer_name!r}"
+                logger.warning(f"PublicAPI: {msg}")
+                self.error_occurred.emit(operation, msg)
+                return False
+
+            success = layer.setSubsetString("")
+            if success:
+                logger.info(f"PublicAPI: Filter cleared on {layer_name!r}")
+                self.filter_cleared.emit(layer_name, "external")
+            else:
+                msg = f"Failed to clear filter on layer {layer_name!r}"
+                logger.warning(f"PublicAPI: {msg}")
+                self.error_occurred.emit(operation, msg)
+
+            return success
+
+        except Exception as e:
+            msg = f"Unexpected error: {e}"
+            logger.error(f"PublicAPI: {operation} - {msg}", exc_info=True)
+            self.error_occurred.emit(operation, msg)
+            return False
+
+    def clear_all_filters(self) -> int:
+        """
+        Clear all active filters on all vector layers.
+
+        Returns:
+            Number of filters that were cleared.
+        """
+        logger.info("PublicAPI: clear_all_filters")
+        cleared_count = 0
+
+        try:
+            project = QgsProject.instance()
+            for layer in project.mapLayers().values():
+                if not isinstance(layer, QgsVectorLayer):
+                    continue
+                if not layer.isValid():
+                    continue
+                subset = layer.subsetString()
+                if subset and subset.strip():
+                    layer_name = layer.name()
+                    success = layer.setSubsetString("")
+                    if success:
+                        cleared_count += 1
+                        self.filter_cleared.emit(layer_name, "external")
+                        logger.debug(
+                            f"PublicAPI: Cleared filter on {layer_name!r}"
+                        )
+                    else:
+                        logger.warning(
+                            f"PublicAPI: Failed to clear filter on "
+                            f"{layer_name!r}"
+                        )
+
+        except Exception as e:
+            msg = f"Unexpected error: {e}"
+            logger.error(
+                f"PublicAPI: clear_all_filters - {msg}", exc_info=True
+            )
+            self.error_occurred.emit("clear_all_filters", msg)
+
+        logger.info(f"PublicAPI: Cleared {cleared_count} filter(s)")
+        return cleared_count
+
+    def get_version(self) -> str:
+        """
+        Return FilterMate version string from metadata.txt.
+
+        Returns:
+            Version string (e.g., '4.6.1').
+        """
+        if self._version is not None:
+            return self._version
+
+        try:
+            plugin_dir = self._plugin.plugin_dir
+            metadata_path = os.path.join(plugin_dir, "metadata.txt")
+
+            if os.path.exists(metadata_path):
+                with open(metadata_path, "r", encoding="utf-8") as f:
+                    for line in f:
+                        line = line.strip()
+                        if line.startswith("version="):
+                            self._version = line.split("=", 1)[1].strip()
+                            return self._version
+
+            self._version = "unknown"
+            logger.warning("PublicAPI: Could not read version from metadata.txt")
+
+        except Exception as e:
+            self._version = "unknown"
+            logger.error(f"PublicAPI: Error reading version: {e}")
+
+        return self._version
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _find_vector_layer(self, layer_name: str):
+        """
+        Find a vector layer by name in the current QGIS project.
+
+        Args:
+            layer_name: Layer name to search for.
+
+        Returns:
+            QgsVectorLayer or None if not found.
+        """
+        project = QgsProject.instance()
+        layers = project.mapLayersByName(layer_name)
+        for layer in layers:
+            if isinstance(layer, QgsVectorLayer):
+                return layer
+        return None
+
+    def _safe_set_subset(self, layer, expression: str) -> bool:
+        """
+        Apply subset string with enhanced error handling.
+
+        Tries to use safe_set_subset_string from infrastructure
+        (which handles PostgreSQL type casting), falls back to
+        native setSubsetString.
+
+        Args:
+            layer: QgsVectorLayer to filter.
+            expression: SQL WHERE clause.
+
+        Returns:
+            True if successful.
+        """
+        try:
+            from ...infrastructure.database.sql_utils import safe_set_subset_string
+            return safe_set_subset_string(layer, expression)
+        except ImportError:
+            logger.debug(
+                "PublicAPI: safe_set_subset_string not available, "
+                "using native setSubsetString"
+            )
+            return layer.setSubsetString(expression)

--- a/core/ports/__init__.py
+++ b/core/ports/__init__.py
@@ -16,6 +16,7 @@ Ports:
 - ConfigRepositoryPort: Interface for configuration storage
 - HistoryRepositoryPort: Interface for history persistence
 - CachePort: Interface for caching services
+- IFilterMatePublicAPI: Interface for inter-plugin communication
 """
 from .backend_port import (  # noqa: F401
     BackendPort,
@@ -66,6 +67,11 @@ from .materialized_view_port import (  # noqa: F401
     ViewConfig,
 )
 
+# Public API Port (v4.7.0 - Sprint 1 Narractive Integration)
+from .public_api_port import (  # noqa: F401
+    IFilterMatePublicAPI,
+)
+
 __all__ = [
     # Backend
     'BackendPort',
@@ -102,4 +108,6 @@ __all__ = [
     'ViewType',
     'ViewInfo',
     'ViewConfig',
+    # Public API (v4.7.0 - Narractive Integration)
+    'IFilterMatePublicAPI',
 ]

--- a/core/ports/public_api_port.py
+++ b/core/ports/public_api_port.py
@@ -1,0 +1,85 @@
+# -*- coding: utf-8 -*-
+"""
+Public API Port Interface.
+
+Defines the abstract contract for inter-plugin communication.
+External plugins (e.g., Narractive) can use this API to apply
+and manage filters on QGIS layers without coupling to FilterMate internals.
+
+This is a PURE PYTHON module with NO QGIS dependencies.
+
+Version: 4.7.0 (Sprint 1 - Narractive Integration)
+"""
+from abc import ABC, abstractmethod
+from typing import Dict
+
+
+class IFilterMatePublicAPI(ABC):
+    """
+    Public API port for inter-plugin communication.
+
+    This port defines the contract that external plugins use to
+    interact with FilterMate filtering capabilities.
+
+    Usage from another plugin:
+        from qgis.utils import plugins
+        fm = plugins.get('filter_mate')
+        if fm:
+            api = fm.get_public_api()
+            api.apply_filter('my_layer', 'population > 10000', source_plugin='narractive')
+    """
+
+    @abstractmethod
+    def apply_filter(self, layer_name: str, filter_expr: str,
+                     source_plugin: str = "external") -> bool:
+        """
+        Apply a filter expression to a named layer.
+
+        Args:
+            layer_name: Name of the QGIS layer to filter.
+            filter_expr: SQL WHERE clause (without WHERE keyword).
+            source_plugin: Name of the calling plugin (for logging/audit).
+
+        Returns:
+            True if filter was applied successfully, False otherwise.
+        """
+
+    @abstractmethod
+    def get_active_filters(self) -> Dict[str, str]:
+        """
+        Return active filters for all layers.
+
+        Returns:
+            Dict mapping layer_name to filter_expression for all layers
+            that currently have an active subset string filter.
+        """
+
+    @abstractmethod
+    def clear_filter(self, layer_name: str) -> bool:
+        """
+        Clear the filter on a specific layer.
+
+        Args:
+            layer_name: Name of the QGIS layer to clear.
+
+        Returns:
+            True if filter was cleared successfully, False otherwise.
+        """
+
+    @abstractmethod
+    def clear_all_filters(self) -> int:
+        """
+        Clear all active filters on all layers.
+
+        Returns:
+            Number of filters that were cleared.
+        """
+
+    @abstractmethod
+    def get_version(self) -> str:
+        """
+        Return FilterMate version string.
+
+        Returns:
+            Version string from metadata.txt (e.g., '4.6.1').
+        """

--- a/filter_mate.py
+++ b/filter_mate.py
@@ -1123,6 +1123,13 @@ class FilterMate:
 
         # print "** UNLOAD FilterMate"
 
+        # v4.7.0: Emit about_to_unload signal for inter-plugin communication
+        if hasattr(self, '_public_api') and self._public_api is not None:
+            try:
+                self._public_api.about_to_unload.emit()
+            except Exception:
+                pass  # Best-effort during shutdown
+
         # Disconnect project change signals using dedicated method
         self._disconnect_auto_activation_signals()
 
@@ -1343,6 +1350,28 @@ class FilterMate:
 
         if cb.isChecked():
             settings.setValue('FilterMate/discord_welcome_dismissed', True)
+
+    def get_public_api(self):
+        """Get the public API instance for inter-plugin communication.
+
+        Returns a singleton FilterMatePublicAPI that external plugins
+        (e.g., Narractive) can use to apply/clear filters and subscribe
+        to filter change signals.
+
+        Returns:
+            FilterMatePublicAPI: The public API adapter instance.
+
+        Example from another plugin:
+            from qgis.utils import plugins
+            fm = plugins.get('filter_mate')
+            if fm:
+                api = fm.get_public_api()
+                api.apply_filter('communes', 'population > 10000', 'narractive')
+        """
+        if not hasattr(self, '_public_api') or self._public_api is None:
+            from .adapters.public_api.filter_mate_public_api import FilterMatePublicAPI
+            self._public_api = FilterMatePublicAPI(self)
+        return self._public_api
 
     def run(self):
         """Run method that loads and starts the plugin"""

--- a/tests/unit/adapters/public_api/__init__.py
+++ b/tests/unit/adapters/public_api/__init__.py
@@ -1,0 +1,1 @@
+# FilterMate Public API Unit Tests

--- a/tests/unit/adapters/public_api/test_public_api.py
+++ b/tests/unit/adapters/public_api/test_public_api.py
@@ -1,0 +1,403 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for FilterMate Public API Adapter.
+
+These tests mock QGIS dependencies so they run without a QGIS environment.
+They verify the public API contract defined in IFilterMatePublicAPI.
+
+Modules tested:
+    - adapters.public_api.filter_mate_public_api (FilterMatePublicAPI)
+    - core.ports.public_api_port (IFilterMatePublicAPI)
+"""
+import importlib.util
+import os
+import sys
+import types
+from unittest.mock import MagicMock, patch, mock_open, call
+
+import pytest
+
+
+# =========================================================================
+# IFilterMatePublicAPI port tests (pure Python, no QGIS)
+# =========================================================================
+
+class TestIFilterMatePublicAPIContract:
+    """Tests for the abstract port interface."""
+
+    def test_port_is_abstract(self):
+        """IFilterMatePublicAPI cannot be instantiated directly."""
+        from core.ports.public_api_port import IFilterMatePublicAPI
+
+        with pytest.raises(TypeError):
+            IFilterMatePublicAPI()
+
+    def test_port_defines_required_methods(self):
+        """Port defines all expected abstract methods."""
+        from core.ports.public_api_port import IFilterMatePublicAPI
+        import inspect
+
+        methods = {
+            name for name, _ in inspect.getmembers(
+                IFilterMatePublicAPI, predicate=inspect.isfunction
+            )
+        }
+        assert "apply_filter" in methods
+        assert "get_active_filters" in methods
+        assert "clear_filter" in methods
+        assert "clear_all_filters" in methods
+        assert "get_version" in methods
+
+    def test_concrete_subclass_must_implement_all(self):
+        """A subclass missing abstract methods cannot be instantiated."""
+        from core.ports.public_api_port import IFilterMatePublicAPI
+
+        class IncompleteAPI(IFilterMatePublicAPI):
+            def apply_filter(self, layer_name, filter_expr, source_plugin="external"):
+                return True
+            # Missing: get_active_filters, clear_filter, clear_all_filters, get_version
+
+        with pytest.raises(TypeError):
+            IncompleteAPI()
+
+
+# =========================================================================
+# Module-level loading of FilterMatePublicAPI via spec_from_file_location
+# (follows the pattern from tests/unit/adapters/backends/ogr/test_filter_executor.py)
+# =========================================================================
+
+ROOT = "filter_mate"
+
+
+def _ensure_public_api_mocks():
+    """Pre-mock all parent modules so relative imports resolve."""
+    if ROOT not in sys.modules:
+        fm = types.ModuleType(ROOT)
+        fm.__path__ = []
+        fm.__package__ = ROOT
+        sys.modules[ROOT] = fm
+
+    # Mock the infrastructure.logging module
+    mock_logger = MagicMock()
+    mock_logging_mod = MagicMock()
+    mock_logging_mod.get_logger.return_value = mock_logger
+
+    mocks = {
+        f"{ROOT}.core": MagicMock(),
+        f"{ROOT}.core.ports": MagicMock(),
+        f"{ROOT}.core.ports.public_api_port": MagicMock(),
+        f"{ROOT}.infrastructure": MagicMock(),
+        f"{ROOT}.infrastructure.logging": mock_logging_mod,
+        f"{ROOT}.infrastructure.database": MagicMock(),
+        f"{ROOT}.infrastructure.database.sql_utils": MagicMock(),
+        f"{ROOT}.adapters": MagicMock(),
+        f"{ROOT}.adapters.public_api": MagicMock(),
+    }
+
+    # Wire up safe_set_subset_string mock
+    mocks[f"{ROOT}.infrastructure.database.sql_utils"].safe_set_subset_string = MagicMock(return_value=True)
+
+    # Wire up IFilterMatePublicAPI from the real port module
+    from core.ports.public_api_port import IFilterMatePublicAPI
+    mocks[f"{ROOT}.core.ports.public_api_port"].IFilterMatePublicAPI = IFilterMatePublicAPI
+
+    for name, mock_obj in mocks.items():
+        if name not in sys.modules:
+            sys.modules[name] = mock_obj
+
+
+_ensure_public_api_mocks()
+
+# Load the module file directly
+_api_path = os.path.normpath(os.path.join(
+    os.path.dirname(__file__),
+    "..", "..", "..", "..",
+    "adapters", "public_api", "filter_mate_public_api.py"
+))
+
+_spec = importlib.util.spec_from_file_location(
+    f"{ROOT}.adapters.public_api.filter_mate_public_api",
+    _api_path,
+)
+_mod = importlib.util.module_from_spec(_spec)
+_mod.__package__ = f"{ROOT}.adapters.public_api"
+sys.modules[_mod.__name__] = _mod
+_spec.loader.exec_module(_mod)
+
+FilterMatePublicAPI = _mod.FilterMatePublicAPI
+
+
+# =========================================================================
+# Fixtures
+# =========================================================================
+
+@pytest.fixture
+def mock_plugin():
+    """Return a mock FilterMate plugin instance."""
+    plugin = MagicMock()
+    plugin.plugin_dir = "/fake/plugin/dir"
+    return plugin
+
+
+def _make_layer(name="test_layer", valid=True, subset="", set_subset_ok=True):
+    """Create a mock vector layer."""
+    layer = MagicMock()
+    layer.name.return_value = name
+    layer.isValid.return_value = valid
+    layer.subsetString.return_value = subset
+    layer.setSubsetString.return_value = set_subset_ok
+    return layer
+
+
+def _make_api(mock_plugin):
+    """Create a FilterMatePublicAPI with mocked signals for assertion."""
+    api = FilterMatePublicAPI(mock_plugin)
+    # Replace mocked signals with fresh MagicMocks so we can assert on emit
+    api.filter_applied = MagicMock()
+    api.filter_cleared = MagicMock()
+    api.error_occurred = MagicMock()
+    api.about_to_unload = MagicMock()
+    return api
+
+
+# =========================================================================
+# FilterMatePublicAPI adapter tests
+# =========================================================================
+
+class TestFilterMatePublicAPIApplyFilter:
+    """Tests for apply_filter method."""
+
+    def test_apply_filter_success(self, mock_plugin):
+        """apply_filter returns True and emits filter_applied signal."""
+        layer = _make_layer("communes", valid=True)
+
+        project = MagicMock()
+        project.mapLayersByName.return_value = [layer]
+
+        with patch.object(_mod, "QgsProject") as mock_qgs:
+            mock_qgs.instance.return_value = project
+            with patch.object(_mod, "QgsVectorLayer", new=type(layer)):
+                api = _make_api(mock_plugin)
+
+                result = api.apply_filter(
+                    "communes", "population > 10000", "narractive"
+                )
+
+                assert result is True
+                api.filter_applied.emit.assert_called_once_with(
+                    "communes", "population > 10000", "narractive"
+                )
+
+    def test_apply_filter_layer_not_found(self, mock_plugin):
+        """apply_filter returns False and emits error when layer not found."""
+        project = MagicMock()
+        project.mapLayersByName.return_value = []
+
+        with patch.object(_mod, "QgsProject") as mock_qgs:
+            mock_qgs.instance.return_value = project
+
+            api = _make_api(mock_plugin)
+            result = api.apply_filter("nonexistent", "id = 1")
+
+            assert result is False
+            api.error_occurred.emit.assert_called_once()
+            args = api.error_occurred.emit.call_args[0]
+            assert "not found" in args[1].lower()
+
+    def test_apply_filter_invalid_layer(self, mock_plugin):
+        """apply_filter returns False when layer is invalid."""
+        layer = _make_layer("bad_layer", valid=False)
+
+        project = MagicMock()
+        project.mapLayersByName.return_value = [layer]
+
+        with patch.object(_mod, "QgsProject") as mock_qgs:
+            mock_qgs.instance.return_value = project
+            with patch.object(_mod, "QgsVectorLayer", new=type(layer)):
+                api = _make_api(mock_plugin)
+
+                result = api.apply_filter("bad_layer", "id = 1")
+                assert result is False
+                api.error_occurred.emit.assert_called_once()
+
+    def test_apply_filter_subset_failure(self, mock_plugin):
+        """apply_filter returns False when setSubsetString fails."""
+        layer = _make_layer("communes", valid=True, set_subset_ok=False)
+
+        project = MagicMock()
+        project.mapLayersByName.return_value = [layer]
+
+        with patch.object(_mod, "QgsProject") as mock_qgs:
+            mock_qgs.instance.return_value = project
+            with patch.object(_mod, "QgsVectorLayer", new=type(layer)):
+                api = _make_api(mock_plugin)
+                # Force _safe_set_subset to return False
+                api._safe_set_subset = MagicMock(return_value=False)
+
+                result = api.apply_filter("communes", "bad sql")
+                assert result is False
+                api.error_occurred.emit.assert_called_once()
+                api.filter_applied.emit.assert_not_called()
+
+    def test_apply_filter_default_source_plugin(self, mock_plugin):
+        """apply_filter uses 'external' as default source_plugin."""
+        layer = _make_layer("communes", valid=True)
+
+        project = MagicMock()
+        project.mapLayersByName.return_value = [layer]
+
+        with patch.object(_mod, "QgsProject") as mock_qgs:
+            mock_qgs.instance.return_value = project
+            with patch.object(_mod, "QgsVectorLayer", new=type(layer)):
+                api = _make_api(mock_plugin)
+                api.apply_filter("communes", "id = 1")
+
+                api.filter_applied.emit.assert_called_once()
+                args = api.filter_applied.emit.call_args[0]
+                assert args[2] == "external"
+
+
+class TestFilterMatePublicAPIClearFilter:
+    """Tests for clear_filter method."""
+
+    def test_clear_filter_success(self, mock_plugin):
+        """clear_filter returns True and emits filter_cleared signal."""
+        layer = _make_layer("communes", valid=True)
+
+        project = MagicMock()
+        project.mapLayersByName.return_value = [layer]
+
+        with patch.object(_mod, "QgsProject") as mock_qgs:
+            mock_qgs.instance.return_value = project
+            with patch.object(_mod, "QgsVectorLayer", new=type(layer)):
+                api = _make_api(mock_plugin)
+
+                result = api.clear_filter("communes")
+
+                assert result is True
+                layer.setSubsetString.assert_called_with("")
+                api.filter_cleared.emit.assert_called_once_with(
+                    "communes", "external"
+                )
+
+    def test_clear_filter_layer_not_found(self, mock_plugin):
+        """clear_filter returns False when layer not found."""
+        project = MagicMock()
+        project.mapLayersByName.return_value = []
+
+        with patch.object(_mod, "QgsProject") as mock_qgs:
+            mock_qgs.instance.return_value = project
+
+            api = _make_api(mock_plugin)
+            result = api.clear_filter("nonexistent")
+            assert result is False
+            api.error_occurred.emit.assert_called_once()
+
+
+class TestFilterMatePublicAPIClearAllFilters:
+    """Tests for clear_all_filters method."""
+
+    def test_clear_all_filters(self, mock_plugin):
+        """clear_all_filters clears all layers with active filters."""
+        filtered_layer = _make_layer("filtered", valid=True, subset="id > 10")
+        clean_layer = _make_layer("clean", valid=True, subset="")
+
+        project = MagicMock()
+        project.mapLayers.return_value = {
+            "l1": filtered_layer, "l2": clean_layer
+        }
+
+        with patch.object(_mod, "QgsProject") as mock_qgs:
+            mock_qgs.instance.return_value = project
+            with patch.object(
+                _mod, "QgsVectorLayer", new=type(filtered_layer)
+            ):
+                api = _make_api(mock_plugin)
+                count = api.clear_all_filters()
+
+                assert count == 1
+                filtered_layer.setSubsetString.assert_called_once_with("")
+                clean_layer.setSubsetString.assert_not_called()
+
+    def test_clear_all_filters_none_active(self, mock_plugin):
+        """clear_all_filters returns 0 when no filters active."""
+        project = MagicMock()
+        project.mapLayers.return_value = {}
+
+        with patch.object(_mod, "QgsProject") as mock_qgs:
+            mock_qgs.instance.return_value = project
+
+            api = _make_api(mock_plugin)
+            count = api.clear_all_filters()
+            assert count == 0
+
+
+class TestFilterMatePublicAPIGetActiveFilters:
+    """Tests for get_active_filters method."""
+
+    def test_get_active_filters(self, mock_plugin):
+        """get_active_filters returns dict of filtered layers."""
+        layer1 = _make_layer("communes", valid=True, subset="population > 5000")
+        layer2 = _make_layer("routes", valid=True, subset="")
+
+        project = MagicMock()
+        project.mapLayers.return_value = {"l1": layer1, "l2": layer2}
+
+        with patch.object(_mod, "QgsProject") as mock_qgs:
+            mock_qgs.instance.return_value = project
+            with patch.object(_mod, "QgsVectorLayer", new=type(layer1)):
+                api = _make_api(mock_plugin)
+                filters = api.get_active_filters()
+
+                assert filters == {"communes": "population > 5000"}
+
+    def test_get_active_filters_empty(self, mock_plugin):
+        """get_active_filters returns empty dict when no filters active."""
+        project = MagicMock()
+        project.mapLayers.return_value = {}
+
+        with patch.object(_mod, "QgsProject") as mock_qgs:
+            mock_qgs.instance.return_value = project
+
+            api = _make_api(mock_plugin)
+            filters = api.get_active_filters()
+            assert filters == {}
+
+
+class TestFilterMatePublicAPIGetVersion:
+    """Tests for get_version method."""
+
+    def test_get_version_reads_metadata(self, mock_plugin):
+        """get_version reads version from metadata.txt."""
+        mock_plugin.plugin_dir = "/fake/dir"
+        metadata_content = "name=FilterMate\nversion=4.6.1\nauthor=imagodata\n"
+
+        api = _make_api(mock_plugin)
+
+        with patch("builtins.open", mock_open(read_data=metadata_content)):
+            with patch("os.path.exists", return_value=True):
+                version = api.get_version()
+                assert version == "4.6.1"
+
+    def test_get_version_caches_result(self, mock_plugin):
+        """get_version caches the version after first read."""
+        mock_plugin.plugin_dir = "/fake/dir"
+        metadata_content = "version=4.6.1\n"
+
+        api = _make_api(mock_plugin)
+
+        with patch("builtins.open", mock_open(read_data=metadata_content)):
+            with patch("os.path.exists", return_value=True):
+                v1 = api.get_version()
+                v2 = api.get_version()
+                assert v1 == v2 == "4.6.1"
+
+    def test_get_version_missing_metadata(self, mock_plugin):
+        """get_version returns 'unknown' when metadata.txt not found."""
+        mock_plugin.plugin_dir = "/fake/dir"
+
+        api = _make_api(mock_plugin)
+
+        with patch("os.path.exists", return_value=False):
+            version = api.get_version()
+            assert version == "unknown"


### PR DESCRIPTION
## Summary
- **IFilterMatePublicAPI** port (ABC) with 5 methods: apply_filter, get_active_filters, clear_filter, clear_all_filters, get_version
- **FilterMatePublicAPI** adapter with PyQt signals (filter_applied, filter_cleared, error_occurred, about_to_unload)
- **get_public_api()** singleton on main FilterMate class + about_to_unload in unload()
- **17 unit tests** (all pass)

Closes #14, #15, #16, #17

## Test plan
- [x] 17 unit tests pass
- [x] 617/619 existing tests pass (2 pre-existing failures)
- [ ] Manual test: load FilterMate in QGIS, call get_public_api(), apply_filter on a layer
- [ ] Manual test: verify signals are emitted on filter apply/clear

🤖 Generated with [Claude Code](https://claude.com/claude-code)